### PR TITLE
Add GenerateFromPasswordWithLimit and Calibrate.

### DIFF
--- a/scrypt.go
+++ b/scrypt.go
@@ -276,7 +276,7 @@ func Calibrate(timeout time.Duration, memMiBytes int, params Params) (Params, er
 	}
 
 	// We have to compensate the lowering of N, by increasing p.
-	for p.P > 0 && p.P < maxInt {
+	for i := 0; i < 10 && p.P > 0; i++ {
 		start := time.Now()
 		if _, err := scrypt.Key(password, salt, p.N, p.R, p.P, p.DKLen); err != nil {
 			return p, err
@@ -284,7 +284,7 @@ func Calibrate(timeout time.Duration, memMiBytes int, params Params) (Params, er
 		dur := time.Since(start)
 		if dur < timeout/2 {
 			p.P = int(float64(p.P)*float64(timeout/dur) + 1)
-		} else if dur > timeout {
+		} else if dur > timeout && p.P > 1 {
 			p.P--
 		} else {
 			break

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -122,9 +122,13 @@ func TestCalibrate(t *testing.T) {
 		{8},
 		{1},
 	} {
-		p, err := scrypt.Calibrate(timeout, tc.MemMiB, scrypt.Params{})
+		var (
+			p   scrypt.Params
+			err error
+		)
+		p, err = scrypt.Calibrate(timeout, tc.MemMiB, p)
 		if err != nil {
-			t.Fatalf("%d. %v", testNum, err)
+			t.Fatalf("%d. %#v: %v", testNum, p, err)
 		}
 		if (128*p.R*p.N)>>20 > tc.MemMiB {
 			t.Errorf("%d. wanted memory limit %d, got %d.", testNum, tc.MemMiB, (128*p.R*p.N)>>20)

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -138,7 +138,7 @@ func TestCalibrate(t *testing.T) {
 		}
 		if dur < timeout/2 {
 			t.Errorf("%d. GenerateFromPassword was too fast (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
-		} else if timeout < dur {
+		} else if timeout+timeout/10 < dur {
 			t.Errorf("%d. GenerateFromPassword took too long (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
 		}
 	}

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -142,7 +142,7 @@ func TestCalibrate(t *testing.T) {
 		}
 		if dur < timeout/2 {
 			t.Errorf("%d. GenerateFromPassword was too fast (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
-		} else if timeout+timeout/10 < dur {
+		} else if timeout*2 < dur {
 			t.Errorf("%d. GenerateFromPassword took too long (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
 		}
 	}

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -109,12 +109,16 @@ func TestDecodeHash(t *testing.T) {
 }
 
 func TestGenerateFromPasswordWithLimit(t *testing.T) {
-	timeout := 2 * time.Second
+	timeout := 1 * time.Second
+	memMiB := 32 << 20
+	p := DefaultParams
 	for _, v := range testParams {
 		start := time.Now()
-		_, err := GenerateFromPasswordWithLimit([]byte(password), v.params, timeout, 256<<20)
+		err := p.Harden(timeout, memMiB)
 		dur := time.Since(start)
 		if err != nil && v.pass == true {
+			t.Fatalf("error was returned for %+v: %v", v.params, err)
+		} else if err == nil && v.pass == false {
 			t.Fatalf("no error was returned when expected for params: %+v", v.params)
 		}
 		if dur > timeout*2 {

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -1,9 +1,12 @@
-package scrypt
+package scrypt_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/elithrar/simple-scrypt"
 )
 
 // Test cases
@@ -14,21 +17,21 @@ var (
 
 var testParams = []struct {
 	pass   bool
-	params Params
+	params scrypt.Params
 }{
-	{true, Params{16384, 8, 1, 32, 64}},
-	{true, Params{16384, 8, 1, 16, 32}},
-	{true, Params{65536, 8, 1, 16, 64}},
-	{true, Params{1048576, 8, 2, 64, 128}},
-	{false, Params{-1, 8, 1, 16, 32}},          // invalid N
-	{false, Params{0, 8, 1, 16, 32}},           // invalid N
-	{false, Params{1 << 31, 8, 1, 16, 32}},     // invalid N
-	{false, Params{16384, 0, 12, 16, 32}},      // invalid R
-	{false, Params{16384, 8, 0, 16, 32}},       // invalid R > maxInt/128/P
-	{false, Params{16384, 1 << 24, 1, 16, 32}}, // invalid R > maxInt/256
-	{false, Params{1 << 31, 8, 0, 16, 32}},     // invalid p < 0
-	{false, Params{4096, 8, 1, 5, 32}},         // invalid SaltLen
-	{false, Params{4096, 8, 1, 16, 2}},         // invalid DKLen
+	{true, scrypt.Params{16384, 8, 1, 32, 64}},
+	{true, scrypt.Params{16384, 8, 1, 16, 32}},
+	{true, scrypt.Params{65536, 8, 1, 16, 64}},
+	{true, scrypt.Params{1048576, 8, 2, 64, 128}},
+	{false, scrypt.Params{-1, 8, 1, 16, 32}},          // invalid N
+	{false, scrypt.Params{0, 8, 1, 16, 32}},           // invalid N
+	{false, scrypt.Params{1 << 31, 8, 1, 16, 32}},     // invalid N
+	{false, scrypt.Params{16384, 0, 12, 16, 32}},      // invalid R
+	{false, scrypt.Params{16384, 8, 0, 16, 32}},       // invalid R > maxInt/128/P
+	{false, scrypt.Params{16384, 1 << 24, 1, 16, 32}}, // invalid R > maxInt/256
+	{false, scrypt.Params{1 << 31, 8, 0, 16, 32}},     // invalid p < 0
+	{false, scrypt.Params{4096, 8, 1, 5, 32}},         // invalid SaltLen
+	{false, scrypt.Params{4096, 8, 1, 16, 2}},         // invalid DKLen
 }
 
 var testHashes = []struct {
@@ -46,7 +49,7 @@ var testHashes = []struct {
 
 func TestGenerateRandomBytes(t *testing.T) {
 	for _, v := range testLengths {
-		_, err := GenerateRandomBytes(v)
+		_, err := scrypt.GenerateRandomBytes(v)
 		if err != nil {
 			t.Fatalf("failed to generate random bytes")
 		}
@@ -55,7 +58,7 @@ func TestGenerateRandomBytes(t *testing.T) {
 
 func TestGenerateFromPassword(t *testing.T) {
 	for _, v := range testParams {
-		_, err := GenerateFromPassword([]byte(password), v.params)
+		_, err := scrypt.GenerateFromPassword([]byte(password), v.params)
 		if err != nil && v.pass == true {
 			t.Fatalf("no error was returned when expected for params: %+v", v.params)
 		}
@@ -63,66 +66,89 @@ func TestGenerateFromPassword(t *testing.T) {
 }
 
 func TestCompareHashAndPassword(t *testing.T) {
-	hash, err := GenerateFromPassword([]byte(password), DefaultParams)
+	hash, err := scrypt.GenerateFromPassword([]byte(password), scrypt.DefaultParams)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := CompareHashAndPassword(hash, []byte(password)); err != nil {
+	if err := scrypt.CompareHashAndPassword(hash, []byte(password)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := CompareHashAndPassword(hash, []byte("invalid-password")); err == nil {
+	if err := scrypt.CompareHashAndPassword(hash, []byte("invalid-password")); err == nil {
 		t.Fatalf("mismatched passwords did not produce an error")
 	}
 
 	invalidHash := []byte("$166$$11$a2ad56a415af5")
-	if err := CompareHashAndPassword(invalidHash, []byte(password)); err == nil {
+	if err := scrypt.CompareHashAndPassword(invalidHash, []byte(password)); err == nil {
 		t.Fatalf("did not identify an invalid hash")
 	}
 
 }
 
 func TestCost(t *testing.T) {
-	hash, err := GenerateFromPassword([]byte(password), DefaultParams)
+	hash, err := scrypt.GenerateFromPassword([]byte(password), scrypt.DefaultParams)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	params, err := Cost(hash)
+	params, err := scrypt.Cost(hash)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(params, DefaultParams) {
+	if !reflect.DeepEqual(params, scrypt.DefaultParams) {
 		t.Fatal("cost mismatch: parameters used did not match those retrieved")
 	}
 }
 
 func TestDecodeHash(t *testing.T) {
 	for _, v := range testHashes {
-		_, _, _, err := decodeHash([]byte(v.hash))
+		_, err := scrypt.Cost([]byte(v.hash))
 		if err == nil && v.pass == false {
 			t.Fatal("invalid hash: did not correctly detect invalid password hash")
 		}
 	}
 }
 
-func TestGenerateFromPasswordWithLimit(t *testing.T) {
-	timeout := 1 * time.Second
-	memMiB := 32 << 20
-	p := DefaultParams
-	for _, v := range testParams {
-		start := time.Now()
-		err := p.Harden(timeout, memMiB)
-		dur := time.Since(start)
-		if err != nil && v.pass == true {
-			t.Fatalf("error was returned for %+v: %v", v.params, err)
-		} else if err == nil && v.pass == false {
-			t.Fatalf("no error was returned when expected for params: %+v", v.params)
+func TestCalibrate(t *testing.T) {
+	timeout := 500 * time.Millisecond
+	for testNum, tc := range []struct {
+		MemMiB int
+	}{
+		{64},
+		{32},
+		{16},
+		{8},
+		{1},
+	} {
+		p, err := scrypt.Calibrate(timeout, tc.MemMiB, scrypt.Params{})
+		if err != nil {
+			t.Fatalf("%d. %v", testNum, err)
 		}
-		if dur > timeout*2 {
-			t.Errorf("Too much time taken: %s instead of %s.", dur, timeout)
+		if (128*p.R*p.N)>>20 > tc.MemMiB {
+			t.Errorf("%d. wanted memory limit %d, got %d.", testNum, tc.MemMiB, (128*p.R*p.N)>>20)
+		}
+		start := time.Now()
+		_, err = scrypt.GenerateFromPassword([]byte(password), p)
+		dur := time.Since(start)
+		t.Logf("GenerateFromPassword with %#v took %s (%v)", p, dur, err)
+		if err != nil {
+			t.Fatalf("%d. GenerateFromPassword with %#v: %v", testNum, p, err)
+		}
+		if dur < timeout/2 {
+			t.Errorf("%d. GenerateFromPassword was too fast (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
+		} else if timeout < dur {
+			t.Errorf("%d. GenerateFromPassword took too long (wanted around %s, got %s) with %#v.", testNum, timeout, dur, p)
 		}
 	}
+}
+
+func ExampleCalibrate() {
+	p, err := scrypt.Calibrate(1*time.Second, 128, scrypt.Params{})
+	if err != nil {
+		panic(err)
+	}
+	dk, err := scrypt.GenerateFromPassword([]byte("super-secret-password"), p)
+	fmt.Printf("generated password is %q (%v)", dk, err)
 }

--- a/scrypt_test.go
+++ b/scrypt_test.go
@@ -3,6 +3,7 @@ package scrypt
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 // Test cases
@@ -103,6 +104,21 @@ func TestDecodeHash(t *testing.T) {
 		_, _, _, err := decodeHash([]byte(v.hash))
 		if err == nil && v.pass == false {
 			t.Fatal("invalid hash: did not correctly detect invalid password hash")
+		}
+	}
+}
+
+func TestGenerateFromPasswordWithLimit(t *testing.T) {
+	timeout := 2 * time.Second
+	for _, v := range testParams {
+		start := time.Now()
+		_, err := GenerateFromPasswordWithLimit([]byte(password), v.params, timeout, 256<<20)
+		dur := time.Since(start)
+		if err != nil && v.pass == true {
+			t.Fatalf("no error was returned when expected for params: %+v", v.params)
+		}
+		if dur > timeout*2 {
+			t.Errorf("Too much time taken: %s instead of %s.", dur, timeout)
 		}
 	}
 }


### PR DESCRIPTION
Time and memory limit the derivation, and allow calibration - no cgo
needed.