### PR TITLE
Travis: Build and run tests for current Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: go
+
 sudo: false
+
 go:
-- 1.2
-- 1.3
-- 1.4
-- 1.5
-- tip
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - tip
+
 install:
   - go get golang.org/x/tools/cmd/vet
+
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ go:
   - 1.7
   - tip
 
-install:
-  - go get golang.org/x/tools/cmd/vet
-
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)


### PR DESCRIPTION
The build error seen in PR #4 is caused by the race detector, which simply uses too much RAM. On my machine with 12GiB I was unable to complete the test TestGenerateFromPassword with race detector enabled, the OOM killer took care of the process.

The commit in here updates the Go version used for Travis up to Go 1.7.

Closes #4