### PR TITLE
Update LICENSE file to reflect Google employee contributions.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Matthew Silverlock (matt@eatsleeprepeat.net)
+Copyright (c) 2015-2018 Matthew Silverlock (matt@eatsleeprepeat.net), Google LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As per https://opensource.google.com/docs/patching/#common-rules -

> If project authors are listed in a LICENSE, COPYING, AUTHORS or similar file, please add Google LLC. if it’s not already there. If Google Inc. is already listed then there is no need to change it to Google LLC. This step only applies if the project authors are listed somewhere.

Updating this to reflect a few boxes I need to tick.