### PR TITLE
fix gotip formatting check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           echo "$(gotip env GOROOT)/bin" >> $GITHUB_PATH
 
       - name: Verify formatting
-        run: gotip fmt -l .
+        run: test -z "$(gofmt -l .)"
 
       - name: Run go vet
         run: gotip vet ./...


### PR DESCRIPTION
`gotip fmt -l .` is invalid — `go fmt` doesn't accept the `-l` flag, so the step always exits 2. Because `continue-on-error: true` is set on the `test-tip` job, the failure is silently swallowed and formatting is never checked for tip.

- replace `gotip fmt -l .` with `test -z "$(gofmt -l .)"`, matching the stable job
- `gofmt` resolves to the gotip version since line 49 already adds gotip's GOROOT/bin to PATH